### PR TITLE
Add PF2e button and tab styles

### DIFF
--- a/styles/pf2e-remaster-green.css
+++ b/styles/pf2e-remaster-green.css
@@ -13,3 +13,19 @@ body {
   line-height: var(--pf2e-line-height);
   background: var(--pf2e-bg-light);
 }
+
+.pf2e-button,
+.pf2e-tab {
+  background: var(--pf2e-primary-accent);
+  color: #FFFFFF;
+}
+
+.pf2e-button:hover,
+.pf2e-tab:hover {
+  background: var(--pf2e-primary-dark);
+}
+
+.pf2e-tab.inactive {
+  background: var(--pf2e-secondary-bg);
+  color: #1C1C1C;
+}

--- a/templates/example.hbs
+++ b/templates/example.hbs
@@ -1,0 +1,5 @@
+<button class="pf2e-button">Example Button</button>
+<nav class="tab-group">
+  <a class="pf2e-tab">Active Tab</a>
+  <a class="pf2e-tab inactive">Inactive Tab</a>
+</nav>


### PR DESCRIPTION
## Summary
- style pf2e buttons and tabs with accent background and dark-hover effect
- add inactive tab styles and example Handlebars template

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd5011b08327a6548cda4fcadbce