### PR TITLE
Add reusable panel and card styles

### DIFF
--- a/styles/pf2e-remaster-green.css
+++ b/styles/pf2e-remaster-green.css
@@ -2,6 +2,8 @@
 :root {
   --pf2e-primary-accent: #3C7C59;
   --pf2e-bg-light: #F8F6F1;
+  --pf2e-primary-dark: #305F47;
+  --pf2e-secondary-bg: #E0E0E0;
   --pf2e-font-family: "Noto Sans", sans-serif;
   --pf2e-font-size: 16px;
   --pf2e-line-height: 1.5;
@@ -28,4 +30,15 @@ body {
 .pf2e-tab.inactive {
   background: var(--pf2e-secondary-bg);
   color: #1C1C1C;
+}
+
+.pf2e-panel,
+.pf2e-card {
+  background: var(--pf2e-bg-light);
+  border: 1px solid var(--pf2e-secondary-bg);
+}
+
+.pf2e-panel:hover,
+.pf2e-card:hover {
+  box-shadow: 0 0 4px rgba(60,124,89,0.15);
 }

--- a/templates/example.hbs
+++ b/templates/example.hbs
@@ -1,5 +1,9 @@
-<button class="pf2e-button">Example Button</button>
-<nav class="tab-group">
-  <a class="pf2e-tab">Active Tab</a>
-  <a class="pf2e-tab inactive">Inactive Tab</a>
-</nav>
+<section class="pf2e-panel">
+  <div class="pf2e-card">
+    <button class="pf2e-button">Example Button</button>
+  </div>
+  <nav class="tab-group">
+    <a class="pf2e-tab">Active Tab</a>
+    <a class="pf2e-tab inactive">Inactive Tab</a>
+  </nav>
+</section>


### PR DESCRIPTION
## Summary
- define theme variables for primary dark and secondary backgrounds
- add `.pf2e-panel` and `.pf2e-card` classes with light background, bordered edges, and subtle hover highlight
- showcase new panel and card structure in example template

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fe22dbd883279f0ddb5797709011