### PR TITLE
Add condition badge styles and handler

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,5 +5,8 @@
   "version": "0.1.0",
   "styles": [
     "styles/pf2e-remaster-green.css"
+  ],
+  "scripts": [
+    "scripts/condition-badges.js"
   ]
 }

--- a/scripts/condition-badges.js
+++ b/scripts/condition-badges.js
@@ -1,0 +1,24 @@
+const BADGE_CLASS_MAP = {
+  success: "pf2e-badge-success",
+  danger: "pf2e-badge-danger",
+  warning: "pf2e-badge-warning",
+  info: "pf2e-badge-info",
+};
+
+function applyBadgeClasses(html) {
+  html.find("[data-badge-type]").each((_, element) => {
+    const type = element.dataset.badgeType;
+    const cls = BADGE_CLASS_MAP[type];
+    if (cls) {
+      element.classList.add("pf2e-badge", cls);
+    }
+  });
+}
+
+Hooks.on("renderTokenHUD", (_hud, html) => {
+  applyBadgeClasses(html);
+});
+
+Hooks.on("renderActorSheet", (_app, html) => {
+  applyBadgeClasses(html);
+});

--- a/styles/pf2e-remaster-green.css
+++ b/styles/pf2e-remaster-green.css
@@ -42,3 +42,27 @@ body {
 .pf2e-card:hover {
   box-shadow: 0 0 4px rgba(60,124,89,0.15);
 }
+
+/* Badge styles */
+.pf2e-badge {
+  color: #FFFFFF;
+  border-radius: 4px;
+  padding: 2px 6px;
+  display: inline-block;
+}
+
+.pf2e-badge-success {
+  background: #3C9D63;
+}
+
+.pf2e-badge-danger {
+  background: #C94F4F;
+}
+
+.pf2e-badge-warning {
+  background: #E6A23C;
+}
+
+.pf2e-badge-info {
+  background: #4A90E2;
+}


### PR DESCRIPTION
## Summary
- add PF2e badge styles for success, danger, warning, and info
- assign badge classes via render hooks for actor sheets and token HUD
- register new script in module manifest

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ff30a1c083278942cf5be7118671